### PR TITLE
correct name of style variables in custom button

### DIFF
--- a/src/app/shared/components/custom-btn/custom-button.component.css
+++ b/src/app/shared/components/custom-btn/custom-button.component.css
@@ -21,12 +21,13 @@
 
 .custom-button:hover {
   background-color: var(--primary-color);
-  color: var(--secondary-light-color);  
+  color: var(--secondary-color-light);  
 }
 
 .custom-button:active {
   background-color: var(--primary-color);
-  border-color: var(--secondary-light-color);
+  border-color: var(--secondary-color-light);
+  color: var(--secondary-color-light);
 }
 
 .custom-button--secondary {
@@ -42,8 +43,8 @@
 
 .custom-button--secondary:active {
   background-color: var(--primary-color);
-  border-color: var(--secondary-light-color);
-  color: var(--secondary-light-color);    
+  border-color: var(--secondary-color-light);
+  color: var(--secondary-color-light);    
 }
 
 .custom-button--red {


### PR DESCRIPTION
# Description:

correct name of style variables in custom button
In several places I had put --secondary-light-color and the property is called --secondary-color-light

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
